### PR TITLE
fix: check sign bytes at `syncLastSignState` & catch raft error and return nil result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.24.3
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/cometbft/cometbft v0.38.18
+	github.com/cosmos/gogoproto v1.7.0
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	go.etcd.io/bbolt v1.4.0-alpha.0.0.20240404170359-43604f3112c5
 	golang.org/x/sync v0.11.0
 )
@@ -26,7 +28,6 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/cometbft/cometbft-db v0.14.1 // indirect
-	github.com/cosmos/gogoproto v1.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/dgraph-io/badger/v4 v4.2.0 // indirect
@@ -68,7 +69,6 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect

--- a/pkg/endpoint/validation.go
+++ b/pkg/endpoint/validation.go
@@ -56,8 +56,8 @@ func ValidationRequestHandler(
 		vote := r.SignVoteRequest.Vote
 
 		err = privVal.SignVote(chainID, vote)
-		if err != nil && strings.Contains(err.Error(), "lease unavailable") {
-			res = privvalproto.Message{}
+		if err != nil && strings.Contains(err.Error(), "raft error") {
+			res = privvalproto.Message{Sum: &privvalproto.Message_SignedVoteResponse{SignedVoteResponse: nil}}
 		} else if err != nil {
 			res = mustWrapMsg(&privvalproto.SignedVoteResponse{
 				Vote: cmtproto.Vote{}, Error: &privvalproto.RemoteSignerError{Code: 0, Description: err.Error()}})
@@ -77,8 +77,8 @@ func ValidationRequestHandler(
 		proposal := r.SignProposalRequest.Proposal
 
 		err = privVal.SignProposal(chainID, proposal)
-		if err != nil && strings.Contains(err.Error(), "lease unavailable") {
-			res = privvalproto.Message{}
+		if err != nil && strings.Contains(err.Error(), "raft error") {
+			res = privvalproto.Message{Sum: &privvalproto.Message_SignedProposalResponse{SignedProposalResponse: nil}}
 		} else if err != nil {
 			res = mustWrapMsg(&privvalproto.SignedProposalResponse{
 				Proposal: cmtproto.Proposal{}, Error: &privvalproto.RemoteSignerError{Code: 0, Description: err.Error()}})

--- a/pkg/endpoint/validation_test.go
+++ b/pkg/endpoint/validation_test.go
@@ -13,7 +13,8 @@ func TestPrivValProtoMessage(t *testing.T) {
 	_, ok := m.GetSum().(*privvalproto.Message_SignedProposalResponse)
 	require.False(t, ok)
 
-	m.Sum = &privvalproto.Message_SignedProposalResponse{SignedProposalResponse: &privvalproto.SignedProposalResponse{}}
-	_, ok = m.GetSum().(*privvalproto.Message_SignedProposalResponse)
+	m.Sum = &privvalproto.Message_SignedProposalResponse{SignedProposalResponse: nil}
+	x, ok := m.GetSum().(*privvalproto.Message_SignedProposalResponse)
 	require.True(t, ok)
+	require.Nil(t, x.SignedProposalResponse)
 }

--- a/pkg/fsm/last_sign_state.go
+++ b/pkg/fsm/last_sign_state.go
@@ -1,6 +1,8 @@
 package fsm
 
 import (
+	"bytes"
+
 	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/privval"
 )
@@ -84,4 +86,23 @@ func (s *LastSignState) EqualHRS(other *LastSignState) bool {
 	}
 
 	return s.Height == other.Height && s.Round == other.Round && s.Step == other.Step
+}
+
+// Equal reports whether s and other have identical HRS and signing payload.
+func (s *LastSignState) Equal(other *LastSignState) bool {
+	if s == nil && other == nil {
+		return true
+	} else if s == nil || other == nil {
+		return false
+	}
+
+	if !s.EqualHRS(other) {
+		return false
+	}
+
+	if !bytes.Equal(s.Signature, other.Signature) {
+		return false
+	}
+
+	return bytes.Equal(s.SignBytes, other.SignBytes)
 }

--- a/pkg/fsm/last_sign_state_test.go
+++ b/pkg/fsm/last_sign_state_test.go
@@ -121,3 +121,60 @@ func TestLastSignStateEqualHRS(t *testing.T) {
 		t.Fatal("expected non-nil vs nil to be unequal")
 	}
 }
+
+func TestLastSignStateEqualFullComparison(t *testing.T) {
+	base := &LastSignState{
+		Height:    9,
+		Round:     1,
+		Step:      2,
+		Signature: []byte{1, 2, 3},
+		SignBytes: []byte{4, 5, 6},
+	}
+
+	if !base.Equal(&LastSignState{
+		Height:    9,
+		Round:     1,
+		Step:      2,
+		Signature: []byte{1, 2, 3},
+		SignBytes: []byte{4, 5, 6},
+	}) {
+		t.Fatal("expected identical sign states to be equal")
+	}
+
+	if base.Equal(&LastSignState{
+		Height:    9,
+		Round:     1,
+		Step:      2,
+		Signature: []byte{1, 2, 3},
+		SignBytes: []byte{9, 5, 6},
+	}) {
+		t.Fatal("expected differing sign bytes to be unequal")
+	}
+
+	if base.Equal(&LastSignState{
+		Height:    9,
+		Round:     1,
+		Step:      2,
+		Signature: []byte{0, 2, 3},
+		SignBytes: []byte{4, 5, 6},
+	}) {
+		t.Fatal("expected differing signatures to be unequal")
+	}
+
+	if base.Equal(&LastSignState{
+		Height:    9,
+		Round:     2,
+		Step:      2,
+		Signature: []byte{1, 2, 3},
+		SignBytes: []byte{4, 5, 6},
+	}) {
+		t.Fatal("expected differing HRS to be unequal")
+	}
+
+	if !(*LastSignState)(nil).Equal(nil) {
+		t.Fatal("expected nil comparisons to be equal")
+	}
+	if base.Equal(nil) || (*LastSignState)(nil).Equal(base) {
+		t.Fatal("expected non-nil vs nil to be unequal")
+	}
+}

--- a/pkg/keyserver/signing_integration_test.go
+++ b/pkg/keyserver/signing_integration_test.go
@@ -666,10 +666,7 @@ func isTemporarySignError(err error) bool {
 	}
 	var remoteErr *privval.RemoteSignerError
 	if errors.As(err, &remoteErr) {
-		if strings.Contains(remoteErr.Description, "lease unavailable") {
-			return true
-		}
-		return false
+		return strings.Contains(remoteErr.Description, "raft error")
 	}
 	return true
 }

--- a/pkg/keyserver/validator.go
+++ b/pkg/keyserver/validator.go
@@ -81,7 +81,7 @@ func (l *PrivValidator) SignProposal(chainID string, proposal *cmtproto.Proposal
 func (l *PrivValidator) syncLastSignState() error {
 	l.mu.Lock()
 	lastSignState := fsm.FromFilePV(&l.inner.LastSignState)
-	if lastSignState.EqualHRS(l.node.GetLastSignState()) {
+	if lastSignState.Equal(l.node.GetLastSignState()) {
 		l.mu.Unlock()
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error classification for consensus-related signing operations so transient raft-related issues are recognized distinctly, improving reliability and clearer responses.
  * Strengthened signing-state comparisons to avoid ambiguous replay/duplication scenarios during consensus signing.

* **Tests**
  * Updated validation and integration tests to reflect refined error handling and to verify the enhanced signing-state equality behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->